### PR TITLE
chore: update deps and fix deprecated `try` macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ license = "MPL-2.0"
 publish = true
 
 [dependencies]
-lazy_static = "0.2"
-regex = "0.2"
-walkdir = "1"
+lazy_static = "1.4"
+regex = "1.7"
+walkdir = "2"

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use error::{Error, Result};
+use crate::error::{Error, Result};
 
 use std::borrow::Cow;
 

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -2,15 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use message::Message;
-use error::{Error, Result};
-use common::{find_string, escape_string};
+use crate::common::{escape_string, find_string};
+use crate::error::{Error, Result};
+use crate::message::Message;
 
 use std::collections::HashMap;
-use std::path::Path;
 use std::fs::File;
 use std::io::Read;
 use std::io::Write;
+use std::path::Path;
 
 use regex::Regex;
 use walkdir::WalkDir;
@@ -39,7 +39,7 @@ pub struct Extractor {
     messages: HashMap<String, Message>,
     // Matches the format string (as used by `lformat!` and the actual escaped string
     // given to potfile
-    orig_strings: HashMap<String, String>, 
+    orig_strings: HashMap<String, String>,
 }
 
 impl Extractor {
@@ -47,7 +47,7 @@ impl Extractor {
     pub fn new() -> Extractor {
         Extractor {
             messages: HashMap::new(),
-            orig_strings: HashMap::new(), 
+            orig_strings: HashMap::new(),
         }
     }
 
@@ -64,35 +64,33 @@ impl Extractor {
             static ref REMOVE_COMMS: Regex = Regex::new(r#"//[^\n]*"#).unwrap();
             static ref FIND_MSGS: Regex = Regex::new(r#"lformat!\("#).unwrap();
         }
-        
-        let filename =  format!("{}", file.as_ref().display());
-        let mut f = try!(File::open(file)
-                         .map_err(|e| Error::parse(format!("could not open file {}: {}",
-                                                           &filename,
-                                                           e))));
+
+        let filename = format!("{}", file.as_ref().display());
+        let mut f = File::open(file)
+            .map_err(|e| Error::parse(format!("could not open file {}: {}", &filename, e)))?;
         let mut content = String::new();
-        try!(f.read_to_string(&mut content)
-            .map_err(|e| Error::parse(format!("could not read file {}: {}",
-                                              &filename,
-                                              e))));
+        f.read_to_string(&mut content)
+            .map_err(|e| Error::parse(format!("could not read file {}: {}", &filename, e)))?;
         content = REMOVE_COMMS.replace_all(&content, "").into_owned();
 
         for caps in FIND_MSGS.captures_iter(&content) {
             let pos = caps.get(0).unwrap().end();
             let line = 1 + &content[..pos].bytes().filter(|b| b == &b'\n').count();
-            
+
             let bytes = content[pos..].as_bytes();
-            let orig_msg: String = try!(find_string(bytes)
-                                   .map_err(|_| Error::parse(format!("{}:{}: could not parse as string",
-                                                                     &filename,
-                                                                     line))));
+            let orig_msg: String = find_string(bytes).map_err(|_| {
+                Error::parse(format!("{}:{}: could not parse as string", &filename, line))
+            })?;
             let msg = escape_string(orig_msg.as_str()).into_owned();
             if msg != orig_msg {
                 self.orig_strings.insert(orig_msg, msg.clone());
             }
-            
+
             if self.messages.contains_key(msg.as_str()) {
-                self.messages.get_mut(&msg).unwrap().add_source(filename.as_str(), line);
+                self.messages
+                    .get_mut(&msg)
+                    .unwrap()
+                    .add_source(filename.as_str(), line);
             } else {
                 let mut message = Message::new(msg.as_str());
                 message.add_source(filename.as_str(), line);
@@ -106,15 +104,13 @@ impl Extractor {
     /// Add messages from all `.rs` files contained in a directory
     /// (walks through subdirectories)
     pub fn add_messages_from_dir<P: AsRef<Path>>(&mut self, dir: P) -> Result<()> {
-        let filtered =  WalkDir::new(dir)
+        let filtered = WalkDir::new(dir)
             .into_iter()
             .filter_map(|e| e.ok())
-            .map(|e| e.path()
-                 .to_string_lossy()
-                 .into_owned())
+            .map(|e| e.path().to_string_lossy().into_owned())
             .filter(|s| s.ends_with(".rs"));
         for filename in filtered {
-            try!(self.add_messages_from_file(&filename));
+            self.add_messages_from_file(&filename)?;
         }
 
         Ok(())
@@ -123,9 +119,7 @@ impl Extractor {
     /// Generate a pot-like file from the strings extracted from all files (if any)
     pub fn generate_pot_file(&self) -> String {
         let mut output = String::from(POT_HEADER);
-        let mut values = self.messages
-            .values()
-            .collect::<Vec<_>>();
+        let mut values = self.messages.values().collect::<Vec<_>>();
         values.sort();
         for value in values {
             output.push_str(&format!("{}", value));
@@ -135,12 +129,11 @@ impl Extractor {
 
     /// Write a pot-like file to specified location
     pub fn write_pot_file(&mut self, file: &str) -> Result<()> {
-        let mut f = try!(File::create(file).map_err(|e| Error::new(format!("Could not create file {}: {}",
-                                                                              file, e))));
+        let mut f = File::create(file)
+            .map_err(|e| Error::new(format!("Could not create file {}: {}", file, e)))?;
         let content = self.generate_pot_file();
-        try!(f.write_all(content.as_bytes())
-             .map_err(|e| Error::new(format!("Could not write to file {}: {}",
-                                             file, e))));
+        f.write_all(content.as_bytes())
+            .map_err(|e| Error::new(format!("Could not write to file {}: {}", file, e)))?;
         Ok(())
     }
 }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use error::{Error,Result};
-use common::find_string;
+use crate::common::find_string;
+use crate::error::{Error, Result};
 
 use std::collections::HashMap;
 
@@ -19,7 +19,9 @@ pub struct Lang {
 impl Lang {
     /// Create a new empty Lang with no content
     pub fn new<S>(lang: S) -> Lang
-        where S: Into<String> {
+    where
+        S: Into<String>,
+    {
         Lang {
             lang: lang.into(),
             content: HashMap::new(),
@@ -36,11 +38,11 @@ impl Lang {
     /// msgstr "Translated string"
     /// ```
     pub fn new_from_str<S>(lang: S, s: &str) -> Result<Lang>
-        where S: Into<String> {
+    where
+        S: Into<String>,
+    {
         let mut lang = Self::new(lang);
-        let lines:Vec<_> = s.lines()
-            .map(|s| s.trim())
-            .collect();
+        let lines: Vec<_> = s.lines().map(|s| s.trim()).collect();
         let mut i = 0;
         while i < lines.len() {
             if lines[i].is_empty() || lines[i].starts_with("#") {
@@ -53,13 +55,15 @@ impl Lang {
                 let mut s = &lines[i][end..];
                 let mut key = String::new();
                 loop {
-                    key.push_str(&try!(find_string(s.as_bytes()).map_err(|e| {
-                        Error::parse(format!("initializing lang '{}' at line {}, could not parse {} as a String: {}",
-                                             &lang.lang, i, s, e))
-                    })));
-                    if i >= lines.len() - 1 || lines[i+1].starts_with("msgstr") {
-                            break;
-                    } else if lines[i+1].starts_with('"') {
+                    key.push_str(&find_string(s.as_bytes()).map_err(|e| {
+                        Error::parse(format!(
+                            "initializing lang '{}' at line {}, could not parse {} as a String: {}",
+                            &lang.lang, i, s, e
+                        ))
+                    })?);
+                    if i >= lines.len() - 1 || lines[i + 1].starts_with("msgstr") {
+                        break;
+                    } else if lines[i + 1].starts_with('"') {
                         i = i + 1;
                         s = lines[i];
                     } else {
@@ -74,14 +78,14 @@ impl Lang {
                     let mut s = &lines[i][end..];
                     let mut value = String::new();
                     loop {
-                        value.push_str(&try!(find_string(s.as_bytes()).map_err(|e| {
+                        value.push_str(&find_string(s.as_bytes()).map_err(|e| {
                         Error::parse(format!("initializing lang '{}' at line {}, could not parse {} as a String: {}",
                                              &lang.lang,
                                              i,
                                              s,
                                              e))
-                        })));
-                        if i >= lines.len() - 1 || lines[i+1].is_empty() {
+                        })?);
+                        if i >= lines.len() - 1 || lines[i + 1].is_empty() {
                             break;
                         } else {
                             i = i + 1;
@@ -96,8 +100,10 @@ impl Lang {
                 }
                 i += 1;
             } else {
-                return Err(Error::parse(format!("initializing lang '{}' at line {}, unexected input: '{}'",
-                                                &lang.lang, i, lines[i])));
+                return Err(Error::parse(format!(
+                    "initializing lang '{}' at line {}, unexected input: '{}'",
+                    &lang.lang, i, lines[i]
+                )));
             }
         }
         Ok(lang)
@@ -109,13 +115,13 @@ impl Lang {
     /// * `key`: the string in default language
     /// * `value`: the translation in this language
     pub fn insert<S1, S2>(&mut self, key: S1, value: S2)
-        where S1: Into<String>,
-              S2: Into<String> {
+    where
+        S1: Into<String>,
+        S2: Into<String>,
+    {
         self.content.insert(key.into(), value.into());
     }
 }
-
-
 
 #[test]
 fn lang_new_valid_1() {
@@ -130,7 +136,6 @@ msgstr "Autre chaîne"
 "#;
     Lang::new_from_str("fr", s).unwrap();
 }
-
 
 #[test]
 fn lang_new_invalid_1() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,6 @@ mod localizer;
 mod message;
 mod extractor;
 
-pub use error::{Result, Error};
-pub use localizer::Localizer;
-pub use extractor::Extractor;
+pub use crate::error::{Result, Error};
+pub use crate::localizer::Localizer;
+pub use crate::extractor::Extractor;

--- a/src/localizer.rs
+++ b/src/localizer.rs
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use lang::Lang;
-use error::{Result, Error};
-use macrogen;
-use extractor::Extractor;
+use crate::lang::Lang;
+use crate::error::{Result, Error};
+use crate::macrogen;
+use crate::extractor::Extractor;
 
 use std::fs::File;
 use std::path::Path;

--- a/src/macrogen.rs
+++ b/src/macrogen.rs
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use lang::Lang;
-use extractor::Extractor;
+use crate::lang::Lang;
+use crate::extractor::Extractor;
 
 /// Generate the `lformat!` macro
 pub fn generate_lformat(langs: &mut [Lang], extractor: &Extractor) -> String {

--- a/src/message.rs
+++ b/src/message.rs
@@ -3,7 +3,7 @@
 // this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::fmt;
-use common::escape_string;
+use crate::common::escape_string;
 
 /// Represents a comment concerning the location/translation of a message
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]


### PR DESCRIPTION
winapi 0.2.8 uses deprecated code, so this PR is to update the dependencies to get rid of it. 
I also replace `try` macros by `?` as the compiler suggested.

`cargo test` is happy :) 